### PR TITLE
ci(lumi): bump bun to 1.3.14 for opencode v1.17.12

### DIFF
--- a/.github/workflows/build_lumi_binary.yaml
+++ b/.github/workflows/build_lumi_binary.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.11'
+          bun-version: '1.3.14'
 
       - name: Install dependencies (from repo root — resolves workspace packages)
         working-directory: opencode-src


### PR DESCRIPTION
The Lumi fork was bumped to opencode **v1.17.12**, which requires **bun ^1.3.14** (root `package.json` `packageManager` field, enforced by a version-guard script/hook).

`build_lumi_binary.yaml` pinned `1.3.11`, so the next build against `dev` fails at `bun install` with:
`This script requires bun@^1.3.14, but you are using bun@1.3.11`.

This bumps the `setup-bun` pin to `1.3.14`. No other changes.